### PR TITLE
fix: add SSL fix

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,10 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": [
+    "node_modules",
+    "test",
+    "prisma",
+    "dist",
+    "**/*spec.ts"
+  ]
 }


### PR DESCRIPTION
# Description

Some new implementations were made that resulted in complications in activating SSL on deploy. 

## Fixes

- Add correction in the build, in the current build the prism folder is taken into account, which results in changing the dist folder structure, breaking the import of SSL certificates;
- Adds web server constructor, which takes into account the ENABLE_SSL environment variable to enable SSL, this way we can enable and disable SSL without having to use NODE_ENV with the value "production", which results in different behavior for some dependencies.